### PR TITLE
Add support for skip$,orderby$ and limit$

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 var Sharder = require('sharder')
 var async = require('async')
 var Seneca = require('seneca')
+var _ = require('underscore');
 var name = 'shard-store'
 
 
@@ -104,19 +105,19 @@ module.exports = function (opts) {
       if (args.cmd === 'list' && args.q) {
         var startindex = 0
         var endindex = result.length
-        var condition = false
+        var limitOrSkip = false
 
         if (skip) {
-          condition = true
+          limitOrSkip = true
           startindex = skip
         }
 
         if (args.q.limit$ && args.q.limit$ !== 'all') {
-          condition = true
-          endindex = args.q.limit$
+          limitOrSkip = true
+          endindex = result.length > args.q.limit$ ? args.q.limit$ : result.length
         }
 
-        if (condition)
+        if (limitOrSkip)
           result = result.slice(startindex, endindex)
       }
       if ((args.cmd === 'save' || args.cmd === 'load') && result.length == 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-shard-store",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Sharding for Seneca",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,8 @@
   "dependencies": {
     "sharder": "0.0.2",
     "async": "0.2.10",
-    "seneca-store-test": "0.2.2"
+    "underscore": "~1.6.0",
+    "node-uuid": "~1.4.1",
+    "seneca-store-test": "git://github.com/piccoloaiutante/seneca-store-test.git#master"
   }
 }


### PR DESCRIPTION
I've added the support for skip$,orderby$ and limit$ api and refactor test to have all them green.
I've also updated the seneca and seneca-store-test version. 
